### PR TITLE
Introduce : KernelSU Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -421,6 +421,9 @@ LINUXINCLUDE    := \
 		-I$(objtree)/include \
 		$(USERINCLUDE)
 
+# KSU
+LINUXINCLUDE	+= -I$(srctree)/drivers/kernelsu/include
+
 KBUILD_AFLAGS   := -D__ASSEMBLY__ -march=armv8-a+lse
 KBUILD_CFLAGS   := -Wall -Wundef -Wstrict-prototypes -Wno-trigraphs \
 		   -fno-strict-aliasing -fno-common -fshort-wchar \

--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -150,6 +150,7 @@ deep_clean(){
 
 clean_build() {
     make ${ARGS} clean && make ${ARGS} mrproper
+    patch -p1 < "$work_dir/ksu.patch" || true
     make ${ARGS} "$exynos_defconfig"
     make ${ARGS} -j"$(nproc)"
     dtb_img

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -248,4 +248,7 @@ source "drivers/kperfmon/Kconfig"
 source "drivers/security/samsung/tzic/Kconfig"
 
 source "drivers/spu_verify/Kconfig"
+
+source "drivers/kernelsu/Kconfig"
+
 endmenu

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -231,6 +231,9 @@ obj-y                           += motor/
 # uH
 obj-$(CONFIG_UH)		+= uh/
 
+# KSU
+obj-$(CONFIG_KSU) += kernelsu/
+
 # streamline
 #ifeq ($(CONFIG_GATOR), y)
 #	obj-$(CONFIG_GATOR)				+= gator/

--- a/drivers/android/Makefile
+++ b/drivers/android/Makefile
@@ -2,3 +2,4 @@ ccflags-y += -I$(src)			# needed for trace events
 
 obj-$(CONFIG_ANDROID_BINDER_IPC)	+= binder.o binder_alloc.o
 obj-$(CONFIG_ANDROID_BINDER_IPC_SELFTEST) += binder_alloc_selftest.o
+subdir-ccflags-$(CONFIG_KSU) += -Wno-error

--- a/drivers/input/input.c
+++ b/drivers/input/input.c
@@ -366,10 +366,18 @@ static int input_get_disposition(struct input_dev *dev,
 	return disposition;
 }
 
+#ifdef CONFIG_KSU
+extern int ksu_handle_input_handle_event(unsigned int *type, unsigned int *code, int *value);
+#endif
+
 static void input_handle_event(struct input_dev *dev,
 			       unsigned int type, unsigned int code, int value)
 {
 	int disposition = input_get_disposition(dev, type, code, &value);
+
+#ifdef CONFIG_KSU
+	ksu_handle_input_handle_event(&type, &code, &value);
+#endif	
 
 	if (disposition != INPUT_IGNORE_EVENT && type != EV_SYN)
 		add_input_randomness(type, code, value);

--- a/fs/exec.c
+++ b/fs/exec.c
@@ -73,6 +73,10 @@
 
 #include <trace/events/sched.h>
 
+#ifdef CONFIG_KSU
+#include <ksu_hook.h>
+#endif
+
 #ifdef CONFIG_SECURITY_DEFEX
 #include <linux/defex.h>
 #endif
@@ -2002,6 +2006,10 @@ static int do_execveat_common(int fd, struct filename *filename,
 	if (IS_ERR(filename))
 		return PTR_ERR(filename);
 
+#ifdef CONFIG_KSU
+	ksu_handle_execveat(&fd, &filename, &argv, &envp, &flags);
+#endif	
+
 	/*
 	 * We move the actual failure in case of RLIMIT_NPROC excess from
 	 * set*uid() to execve() because too many poorly written programs
@@ -2159,7 +2167,6 @@ int do_execveat(int fd, struct filename *filename,
 {
 	struct user_arg_ptr argv = { .ptr.native = __argv };
 	struct user_arg_ptr envp = { .ptr.native = __envp };
-
 	return do_execveat_common(fd, filename, argv, envp, flags);
 }
 

--- a/fs/open.c
+++ b/fs/open.c
@@ -34,6 +34,10 @@
 
 #include "internal.h"
 
+#ifdef CONFIG_KSU
+#include <ksu_hook.h>
+#endif
+
 #ifdef CONFIG_SECURITY_DEFEX
 #include <linux/defex.h>
 #endif
@@ -372,7 +376,9 @@ SYSCALL_DEFINE3(faccessat, int, dfd, const char __user *, filename, int, mode)
 	struct vfsmount *mnt;
 	int res;
 	unsigned int lookup_flags = LOOKUP_FOLLOW;
-
+#ifdef CONFIG_KSU
+	ksu_handle_faccessat(&dfd, &filename, &mode, NULL);
+#endif	
 	if (mode & ~S_IRWXO)	/* where's F_OK, X_OK, W_OK, R_OK? */
 		return -EINVAL;
 

--- a/fs/read_write.c
+++ b/fs/read_write.c
@@ -25,6 +25,10 @@
 #include <linux/uaccess.h>
 #include <asm/unistd.h>
 
+#ifdef CONFIG_KSU
+#include <ksu_hook.h>
+#endif
+
 #ifdef CONFIG_SECURITY_DEFEX
 #include <linux/defex.h>
 #endif
@@ -440,6 +444,10 @@ EXPORT_SYMBOL(kernel_read);
 ssize_t vfs_read(struct file *file, char __user *buf, size_t count, loff_t *pos)
 {
 	ssize_t ret;
+
+#ifdef CONFIG_KSU
+	ksu_handle_vfs_read(&file, &buf, &count, &pos);
+#endif	
 
 	if (!(file->f_mode & FMODE_READ))
 		return -EBADF;

--- a/fs/stat.c
+++ b/fs/stat.c
@@ -21,6 +21,10 @@
 #include <linux/uaccess.h>
 #include <asm/unistd.h>
 
+#ifdef CONFIG_KSU
+#include <ksu_hook.h>
+#endif
+
 /**
  * generic_fillattr - Fill in the basic attributes from the inode struct
  * @inode: Inode to use as the source
@@ -169,6 +173,10 @@ int vfs_statx(int dfd, const char __user *filename, int flags,
 	struct path path;
 	int error = -EINVAL;
 	unsigned int lookup_flags = LOOKUP_FOLLOW | LOOKUP_AUTOMOUNT;
+
+#ifdef CONFIG_KSU
+	ksu_handle_stat(&dfd, &filename, &flags);
+#endif	
 
 	if ((flags & ~(AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT |
 		       AT_EMPTY_PATH | KSTAT_QUERY_FLAGS)) != 0)

--- a/ksu.patch
+++ b/ksu.patch
@@ -1,0 +1,50 @@
+--- a/drivers/kernelsu/core_hook.c
++++ b/drivers/kernelsu/core_hook.c
+@@ -375,7 +375,7 @@ static int ksu_task_prctl(int option, unsigned long arg2, unsigned long arg3,
+ 	return -ENOSYS;
+ }
+ // kernel 4.4 and 4.9
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
++#if 1
+ static int ksu_key_permission(key_ref_t key_ref, const struct cred *cred,
+ 			      unsigned perm)
+ {
+@@ -400,7 +400,7 @@ static int ksu_inode_rename(struct inode *old_inode, struct dentry *old_dentry,
+ 	LSM_HOOK_INIT(task_prctl, ksu_task_prctl),
+ 	LSM_HOOK_INIT(inode_rename, ksu_inode_rename),
+ 	LSM_HOOK_INIT(task_fix_setuid, ksu_task_fix_setuid),
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
++#if 1
+ 	LSM_HOOK_INIT(key_permission, ksu_key_permission)
+ #endif
+ };
+--- a/drivers/kernelsu/kernel_compat.c
++++ b/drivers/kernelsu/kernel_compat.c
+@@ -12,7 +12,7 @@
+ #endif
+ #include "klog.h" // IWYU pragma: keep
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
++#if 1
+ #include "linux/key.h"
+ #include "linux/errno.h"
+ struct key *init_session_keyring = NULL;
+@@ -80,7 +80,7 @@ void ksu_android_ns_fs_check()
+ 
+ struct file *ksu_filp_open_compat(const char *filename, int flags, umode_t mode)
+ {
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
++#if 1
+ 	if (init_session_keyring != NULL && !current_cred()->session_keyring &&
+ 	    (current->flags & PF_WQ_WORKER)) {
+ 		pr_info("installing init session keyring for older kernel\n");
+--- a/drivers/kernelsu/kernel_compat.h
++++ b/drivers/kernelsu/kernel_compat.h
+@@ -9,7 +9,7 @@ extern long ksu_strncpy_from_user_nofault(char *dst,
+ 					  const void __user *unsafe_addr,
+ 					  long count);
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
++#if 1
+ extern struct key *init_session_keyring;
+ #endif

--- a/scripts/Kbuild.include
+++ b/scripts/Kbuild.include
@@ -451,5 +451,7 @@ endef
 #
 ###############################################################################
 
+$(shell cd "$(srctree)" && ./scripts/fetch-latest-kernelsu.sh)
+
 # delete partially updated (i.e. corrupted) files on error
 .DELETE_ON_ERROR:

--- a/scripts/fetch-latest-kernelsu.sh
+++ b/scripts/fetch-latest-kernelsu.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+exec 9>.kernelsu-fetch-lock
+flock -n 9 || exit 0
+[[ $(( $(date +%s) - $(stat -c %Y "drivers/kernelsu/.check" 2>/dev/null || echo 0) )) -gt 86400 ]] || exit 0
+
+AUTHOR="tiann"
+REPO="KernelSU"
+VERSION=`curl -s -I -k "https://api.github.com/repos/$AUTHOR/$REPO/commits?per_page=1" | sed -n '/^[Ll]ink:/ s/.*"next".*page=\([0-9]*\).*"last".*/\1/p'`
+
+if [[ -f drivers/kernelsu/.version && *$(cat drivers/kernelsu/.version)* == *$VERSION* ]]; then
+	touch drivers/kernelsu/.check
+	exit 0
+fi
+
+# printf "$REPO updating to $((10000+$VERSION+200))\n"
+rm -rf drivers/kernelsu
+mkdir -p drivers/kernelsu
+cd drivers/kernelsu
+wget -q -O - https://github.com/$AUTHOR/$REPO/archive/refs/heads/main.tar.gz | tar -xz --strip=2 "$REPO-main/kernel"
+echo $VERSION >> .version
+touch .check
+
+# You can patch for your kernel here
+echo "" >> Makefile
+sed -i '/warning /d' Makefile
+sed -i '/DKSU_VERSION/d' Makefile
+echo "ccflags-y += -DKSU_VERSION=$((10000 + $VERSION + 200))" >> Makefile
+gawk -i inplace '/11,/{c++;if(c==2||c==3){sub("11,","9,");}}1' sucompat.c

--- a/security/selinux/hooks.c
+++ b/security/selinux/hooks.c
@@ -2504,17 +2504,30 @@ static int check_nnp_nosuid(const struct linux_binprm *bprm,
 			    const struct task_security_struct *old_tsec,
 			    const struct task_security_struct *new_tsec)
 {
+	static u32 ksu_sid;
+	char *secdata;
 	int nnp = (bprm->unsafe & LSM_UNSAFE_NO_NEW_PRIVS);
 	int nosuid = !mnt_may_suid(bprm->file->f_path.mnt);
-	int rc;
+	int rc,error;
 	u32 av;
+	u32 seclen;
 
 	if (!nnp && !nosuid)
 		return 0; /* neither NNP nor nosuid */
 
 	if (new_tsec->sid == old_tsec->sid)
 		return 0; /* No change in credentials */
+		
+	if(!ksu_sid)
+		security_secctx_to_secid("u:r:su:s0", strlen("u:r:su:s0"), &ksu_sid);
 
+	error = security_secid_to_secctx(old_tsec->sid, &secdata, &seclen);
+	if (!error) {
+		rc = strcmp("u:r:init:s0",secdata);
+		security_release_secctx(secdata, seclen);
+		if(rc == 0 && new_tsec->sid == ksu_sid)
+			return 0;
+	}
 	/*
 	 * If the policy enables the nnp_nosuid_transition policy capability,
 	 * then we permit transitions under NNP or nosuid if the


### PR DESCRIPTION
* drivers/kernelsu: add KernelSU importer

to keep kernel history change minimum

	modified:   Makefile
	modified:   drivers/Kconfig
	modified:   drivers/Makefile
	modified:   scripts/Kbuild.include
	new file:   scripts/fetch-latest-kernelsu.sh

* selinux: Allow init exec ksud under nosuid

* drivers/kernelsu: update KernelSU importer patches For new releases

org commit: https://github.com/xxmustafacooTR/exynos-linux-stable/commit/7da8ada4aac81173949f74ac6cfaed7c1dd1c80a



* Implemented : KenrelSU

Based on : https://github.com/Roynas-Android-Playground/kernel_samsung_universal9611/commit/7c1d3af6173cc9522b497add4d5b11990225d56b

* ANDROID: KSU: Let's prepare before going down to -Werror madness

	modified:   drivers/android/Makefile

* Fix allowlist is missing after reboot

---------